### PR TITLE
Omite seção "outros nomes" e "distribuição" quando vazias

### DIFF
--- a/web/src/components/Taxon.astro
+++ b/web/src/components/Taxon.astro
@@ -48,7 +48,7 @@ import TaxonLink from './TaxonLink.astro'
       'Citação bibliográfica': json.bibliographicCitation
     }}
   />
-  <h3 class="pt-2 font-bold">Outros nomes</h3>
+  <h2 class="pt-2 font-bold">Outros nomes</h2>
   <ul class="list-disc list-inside">
     {
       json.othernames?.map(
@@ -84,7 +84,7 @@ import TaxonLink from './TaxonLink.astro'
   {
     json.vernacularname && (
       <>
-        <h3 class="pt-2 font-bold">Nomes vernaculares</h3>
+        <h2 class="pt-2 font-bold">Nomes vernaculares</h2>
         {json.vernacularname?.map(({ vernacularName, language, locality }) => (
           <div class="border-l-4 border-slate-200 pl-1 mb-2">
             <Section

--- a/web/src/components/Taxon.astro
+++ b/web/src/components/Taxon.astro
@@ -48,29 +48,36 @@ import TaxonLink from './TaxonLink.astro'
       'Citação bibliográfica': json.bibliographicCitation
     }}
   />
-  <h2 class="pt-2 font-bold">Outros nomes</h2>
-  <ul class="list-disc list-inside">
-    {
-      json.othernames?.map(
-        ({ taxonID, taxonomicStatus }) => (
-          <li class="pl-2">
-            <TaxonLink taxonId={taxonID} /> - {taxonomicStatus}
-          </li>
-        )
-      )
-    }
-  </ul>
-  <Section
-    title="Distribuição"
-    fields={{
-      Origem: json.distribution?.origin,
-      Endemismo: json.distribution?.endemism,
-      'Domínios fitogeográficos':
-        json.distribution?.phytogeographicDomains?.join(', '),
-      Ocorrência: json.distribution?.occurrence?.sort().join(', '),
-      'Tipo de vegetação': json.distribution?.vegetationType?.join(', ')
-    }}
-  />
+  {
+    json.othernames?.length > 0 && (
+      <>
+        <h2 class="pt-2 font-bold">Outros nomes</h2>
+        <ul class="list-disc list-inside">
+          {json.othernames?.map(({ taxonID, taxonomicStatus }) => (
+            <li class="pl-2">
+              <TaxonLink taxonId={taxonID} /> - {taxonomicStatus}
+            </li>
+          ))}
+        </ul>
+      </>
+    )
+  }
+
+  {
+    Object.keys(json.distribution ?? {}).length > 0 && (
+      <Section
+        title="Distribuição"
+        fields={{
+          Origem: json.distribution?.origin,
+          Endemismo: json.distribution?.endemism,
+          'Domínios fitogeográficos':
+            json.distribution?.phytogeographicDomains?.join(', '),
+          Ocorrência: json.distribution?.occurrence?.sort().join(', '),
+          'Tipo de vegetação': json.distribution?.vegetationType?.join(', ')
+        }}
+      />
+    )
+  }
   <Section
     title="Referência"
     fields={{


### PR DESCRIPTION
Conserta #19

Exemplos:
* Sem "outros nomes": [Nesse branch](https://dwca2json-vty7es28hkzm.deno.dev/taxon/121882) | [Produção](https://dwca2json.deno.dev/taxon/121882)
* Sem "distribuição": [Nesse branch](https://dwca2json-vty7es28hkzm.deno.dev/taxon/114644) | [Produção](https://dwca2json.deno.dev/taxon/114644)