### PR TITLE
Fix: Add --rm and --cleanup flags to ssh-deploy workflow

### DIFF
--- a/.github/workflows/ssh-deploy.yml
+++ b/.github/workflows/ssh-deploy.yml
@@ -14,5 +14,5 @@ jobs:
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_DEPLOY_KEY }}
           script: |
-            docker run -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower DwC2JSON --run-once
+            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock containrrr/watchtower DwC2JSON --run-once --cleanup
 


### PR DESCRIPTION
This change ensures that the Watchtower container removes itself after execution and also cleans up old application container images to prevent orphaned containers.